### PR TITLE
Disabled mouse input on EditBox in locked mode

### DIFF
--- a/channel_monitor.lua
+++ b/channel_monitor.lua
@@ -228,10 +228,12 @@ function channel_monitor:show()
 	self.main_frame.editbox:SetAlpha(1)
 	self.main_frame:SetBackdropColor(0, 0, 0, .45)
 	self.main_frame:EnableMouse(true)
+	self.main_frame.editbox:EnableMouse(true)
 end
 
 function channel_monitor:hide()
 	self.main_frame.editbox:SetAlpha(0)
 	self.main_frame:SetBackdropColor(0, 0, 0, 0)
 	self.main_frame:EnableMouse(false)
+	self.main_frame.editbox:EnableMouse(false)
 end


### PR DESCRIPTION
I noticed (by accident) that you can by hit invisible frame and remove / change all the text in it. I don't like this behavior.
